### PR TITLE
add "istioctlenv-cd [<version>]" command

### DIFF
--- a/libexec/istioctlenv-cd
+++ b/libexec/istioctlenv-cd
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -uo pipefail;
+
+####################################
+# Ensure we can execute standalone #
+####################################
+
+function early_death() {
+  echo "[FATAL] ${0}: ${1}" >&2;
+  exit 1;
+};
+
+if [ -z "${ISTIOCTLENV_ROOT:-""}" ]; then
+  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+  readlink_f() {
+    local target_file="${1}";
+    local file_name;
+
+    while [ "${target_file}" != "" ]; do
+      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine ISTIOCTLENV_ROOT";
+      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine ISTIOCTLENV_ROOT";
+      target_file="$(readlink "${file_name}")";
+    done;
+
+    echo "$(pwd -P)/${file_name}";
+  };
+
+  ISTIOCTLENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
+  [ -n "${ISTIOCTLENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine ISTIOCTLENV_ROOT";
+else
+  ISTIOCTLENV_ROOT="${ISTIOCTLENV_ROOT%/}";
+fi;
+export ISTIOCTLENV_ROOT;
+
+if [ -n "${ISTIOCTLENV_HELPERS:-""}" ]; then
+  log 'debug' 'ISTIOCTLENV_HELPERS is set, not sourcing helpers again';
+else
+  [ "${ISTIOCTLENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${ISTIOCTLENV_ROOT}/lib/helpers.sh";
+  if source "${ISTIOCTLENV_ROOT}/lib/helpers.sh"; then
+    log 'debug' 'Helpers sourced successfully';
+  else
+    early_death "Failed to source helpers from ${ISTIOCTLENV_ROOT}/lib/helpers.sh";
+  fi;
+fi;
+
+# Ensure libexec and bin are in $PATH
+for dir in libexec bin; do
+  case ":${PATH}:" in
+    *:${ISTIOCTLENV_ROOT}/${dir}:*) log 'debug' "\$PATH already contains '${ISTIOCTLENV_ROOT}/${dir}', not adding it again";;
+    *) 
+      log 'debug' "\$PATH does not contain '${ISTIOCTLENV_ROOT}/${dir}', prepending and exporting it now";
+      export PATH="${ISTIOCTLENV_ROOT}/${dir}:${PATH}";
+      ;;
+  esac;
+done;
+
+#####################
+# Begin Script Body #
+#####################
+
+declare requested="${1:-""}";
+
+log debug "Resolving version with: istioctlenv-resolve-version ${requested}";
+declare resolved="$(istioctlenv-resolve-version ${requested})";
+declare version="${resolved%%\:*}";
+export ISTIOCTLENV_VERSION=${version}
+
+if [ ! -d "${ISTIOCTLENV_ROOT}/versions/${ISTIOCTLENV_VERSION}" ]; then
+  if [ "${ISTIOCTLENV_AUTO_INSTALL:-true}" == "true" ]; then
+    log 'info' "version '${ISTIOCTLENV_VERSION}' is not installed (set by $(istioctlenv-version-file)). Installing now as ISTIOCTLENV_AUTO_INSTALL==true";
+    istioctlenv-install;
+  else
+    log 'error' "version '${ISTIOCTLENV_VERSION}' was requested, but not installed and ISTIOCTLENV_AUTO_INSTALL is not 'true'";
+  fi;
+fi;
+
+cd "${ISTIOCTLENV_ROOT}/versions/${ISTIOCTLENV_VERSION}";
+
+exec $SHELL


### PR DESCRIPTION
Add a new command to exec to specified istioctl directory.

`istioctlenv cd` will change working directory to current istioctl versions install dir.

`istioctlenv cd 1.68` will change working directory to istioctl 1.6.8 install directory.